### PR TITLE
Keploy SDK Modes added in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,37 @@ ok      echo-psql-url-shortener 5.820s  coverage: 74.4% of statements in ./...
 
 All of these can be visualised here - http://localhost:8081/testlist
 
+## Keploy SDK Modes
+### SDK Modes
+**The Keploy SDKs modes can operated by setting `KEPLOY_MODE` environment variable**
+
+**Note: KEPLOY_MODE value is case sensitive**
+
+There are 3 Keploy SDK modes:
+
+1. **Off** : In the off mode the Keploy SDK will turn off all the functionality provided by the Keploy platform.
+
+```
+export KEPLOY_MODE="off"
+```
+2. **Record mode** :
+	* Record requests, response and all external calls and sends to Keploy server.
+	* After keploy server removes duplicates, it then runs the request on the API again to identify noisy fields.
+	* Sends the noisy fields to the keploy server to be saved along with the testcase.
+
+```
+export KEPLOY_MODE="record"
+```
+3. **Test mode** :
+	* Fetches testcases for the app from keploy server.
+	* Calls the API with same request payload in testcase.
+	* Mocks external calls based on data stored in the testcase.
+	* Validates the responses and uploads results to the keploy server
+```
+export KEPLOY_MODE="test"
+```
+
+
 ## Language Support
 - [x] [Go SDK](https://github.com/keploy/go-sdk)
 - [x] [Java SDK](https://github.com/keploy/java-sdk)


### PR DESCRIPTION
#64 fixed

**Keploy SDK Modes added in the README.md**

**The details of the SDK Modes has been fetched from the Keploy Documentation**

**Users will have better understanding about different modes and what exactly needs to be set in the env variable since it's currently case sensitive**


